### PR TITLE
fix: persist session state after toggling order direction

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -429,6 +429,7 @@ class Component extends BaseComponent
         $this->toggleOrderDirection();
 
         $this->orderBy = $field;
+        $this->saveSessionState();
     }
 
     public function handleSelectedLetter($selectedLetter): void


### PR DESCRIPTION
Sort Order was not persisting.  This fixes sort order to be included in session state.